### PR TITLE
fix(tasks): reintroduce filter bug for Task 2 Part A

### DIFF
--- a/backend/app/routers/interactions.py
+++ b/backend/app/routers/interactions.py
@@ -15,7 +15,7 @@ def _filter_by_item_id(
 ) -> list[InteractionLog]:
     if item_id is None:
         return interactions
-    return [i for i in interactions if i.item_id == item_id]
+    return [i for i in interactions if i.learner_id == item_id]
 
 
 @router.get("/", response_model=list[InteractionModel])

--- a/backend/tests/unit/test_interactions.py
+++ b/backend/tests/unit/test_interactions.py
@@ -24,9 +24,3 @@ def test_filter_returns_interaction_with_matching_ids() -> None:
     result = _filter_by_item_id(interactions, 1)
     assert len(result) == 1
     assert result[0].id == 1
-
-
-def test_filter_excludes_interaction_with_different_learner_id() -> None:
-    interactions = [_make_log(1, 2, 1)]
-    result = _filter_by_item_id(interactions, 1)
-    assert len(result) == 1


### PR DESCRIPTION
## Summary
- Revert `_filter_by_item_id` to compare `learner_id` instead of `item_id` — the intentional bug students must discover
- Remove the unit test that catches this bug — students must write it themselves per Task 2 step 1.3.2

Without this, Task 2 Part A doesn't work: all tests pass immediately and there's nothing to fix.