### PR TITLE
fix(tasks): reintroduce model bug for Task 2 Part B

### DIFF
--- a/backend/app/models/interaction.py
+++ b/backend/app/models/interaction.py
@@ -24,4 +24,4 @@ class InteractionModel(SQLModel):
     learner_id: int
     item_id: int
     kind: str
-    created_at: datetime
+    timestamp: datetime

--- a/backend/tests/e2e/test_interactions.py
+++ b/backend/tests/e2e/test_interactions.py
@@ -1,13 +1,1 @@
 """End-to-end tests for the GET /interactions endpoint."""
-
-import httpx
-
-
-def test_get_interactions_returns_200(client: httpx.Client) -> None:
-    response = client.get("/interactions/")
-    assert response.status_code == 200
-
-
-def test_get_interactions_response_is_a_list(client: httpx.Client) -> None:
-    response = client.get("/interactions/")
-    assert isinstance(response.json(), list)


### PR DESCRIPTION
## Summary
- Revert `InteractionModel.created_at` back to `timestamp` — the intentional field name mismatch students must discover
- Remove the two e2e tests that catch this bug — students must write them themselves per Task 2 step 1.4.3

Without this, Task 2 Part B doesn't work: e2e tests pass immediately and there's no 500 error to diagnose.