### PR TITLE
fix(config): enable interactions endpoint by default

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -11,7 +11,7 @@ APP_HOST_PORT=42001
 API_TOKEN=my-secret-api-key
 
 # enable endpoints (feature flags)
-ENABLE_INTERACTIONS=false
+ENABLE_INTERACTIONS=true
 ENABLE_LEARNERS=false
 
 # postgres


### PR DESCRIPTION
## Summary
- Set `ENABLE_INTERACTIONS=true` in `.env.docker.example`

Tasks 1 and 2 require the `/interactions` endpoint. With the default `false`, students copy the example to `.env.docker.secret` (as instructed in setup) and the endpoint never registers — Swagger won't show it and e2e tests get 404 instead of the expected 500.