### PR TITLE
feat: add POST /interactions endpoint and fix docs naming

### DIFF
--- a/backend/app/db/interactions.py
+++ b/backend/app/db/interactions.py
@@ -10,3 +10,19 @@ async def read_interactions(session: AsyncSession) -> list[InteractionLog]:
     """Read all interactions from the database."""
     result = await session.exec(select(InteractionLog))
     return list(result.all())
+
+
+async def create_interaction(
+    session: AsyncSession,
+    learner_id: int,
+    item_id: int,
+    kind: str,
+) -> InteractionLog:
+    """Create a new interaction log in the database."""
+    interaction = InteractionLog(
+        learner_id=learner_id, item_id=item_id, kind=kind
+    )
+    session.add(interaction)
+    await session.commit()
+    await session.refresh(interaction)
+    return interaction

--- a/backend/app/models/interaction.py
+++ b/backend/app/models/interaction.py
@@ -17,6 +17,14 @@ class InteractionLog(SQLModel, table=True):
     created_at: datetime | None = Field(default=None)
 
 
+class InteractionLogCreate(SQLModel):
+    """Request schema for creating an interaction log."""
+
+    learner_id: int
+    item_id: int
+    kind: str
+
+
 class InteractionModel(SQLModel):
     """Response schema for an interaction."""
 

--- a/backend/app/routers/interactions.py
+++ b/backend/app/routers/interactions.py
@@ -1,11 +1,12 @@
 """Router for interaction endpoints."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.database import get_session
-from app.db.interactions import read_interactions
-from app.models.interaction import InteractionLog, InteractionModel
+from app.db.interactions import create_interaction, read_interactions
+from app.models.interaction import InteractionLog, InteractionLogCreate, InteractionModel
 
 router = APIRouter()
 
@@ -26,3 +27,22 @@ async def get_interactions(
     """Get all interactions, optionally filtered by item."""
     interactions = await read_interactions(session)
     return _filter_by_item_id(interactions, item_id)
+
+
+@router.post("/", response_model=InteractionLog, status_code=201)
+async def post_interaction(
+    body: InteractionLogCreate, session: AsyncSession = Depends(get_session)
+):
+    """Create a new interaction log."""
+    try:
+        return await create_interaction(
+            session,
+            learner_id=body.learner_id,
+            item_id=body.item_id,
+            kind=body.kind,
+        )
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="learner_id or item_id does not reference an existing record",
+        )

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -169,7 +169,7 @@ graph TD
     subgraph "FastAPI Application"
         subgraph "HTTP Routers"
             IR["Items Router\nGET /items\nGET /items/{id}\nPOST /items\nPUT /items/{id}"]
-            INTR["Interactions Router\nGET /interactions"]
+            INTR["Interactions Router\nGET /interactions\nPOST /interactions"]
             LR["Learners Router\nGET /learners\nPOST /learners"]
         end
 
@@ -213,7 +213,7 @@ graph TD
 | Component           | File                      | Description                                                                                                      |
 | ------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Items Router        | `routers/items.py`        | CRUD endpoints for learning items. Always enabled.                                                               |
-| Interactions Router | `routers/interactions.py` | Read endpoints for interaction logs. Enabled via `ENABLE_INTERACTIONS=true`.                                     |
+| Interactions Router | `routers/interactions.py` | Read and create endpoints for interaction logs. Enabled via `ENABLE_INTERACTIONS=true`.                           |
 | Learners Router     | `routers/learners.py`     | CRUD endpoints for learner profiles. Enabled via `ENABLE_LEARNERS=true`.                                         |
 | Auth Middleware     | `auth.py`                 | Validates the `Authorization: Bearer <token>` header on every request. Token configured via `API_TOKEN` env var. |
 | Items DB            | `db/items.py`             | Async database operations for the `item` table.                                                                  |

--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -61,7 +61,7 @@ Title: `[Task] Observe System Component Interaction`
 
 ### 1.5. Send a request and observe
 
-1. In `Swagger UI`, expand the `POST /interaction_logs` endpoint.
+1. In `Swagger UI`, expand the `POST /interactions` endpoint.
 2. Click `Try it out`.
 3. Enter a request body in [`JSON`](../../../wiki/file-formats.md#json) format, for example:
 
@@ -74,7 +74,7 @@ Title: `[Task] Observe System Component Interaction`
    ```
 
 4. Click `Execute`.
-5. In the browser developer tools `Network` tab, find the request to `/interaction_logs`.
+5. In the browser developer tools `Network` tab, find the request to `/interactions`.
 6. Click on the request to open its details.
 7. Observe the following:
    - The `Headers` tab: the [HTTP method](../../../wiki/http.md#http-method) and the request URL.
@@ -87,22 +87,22 @@ Title: `[Task] Observe System Component Interaction`
 ### 1.6. Verify in `pgAdmin`
 
 1. [Open `pgAdmin`](../../../wiki/pgadmin.md#open-pgadmin).
-2. [Run a query](../../../wiki/pgadmin.md#run-a-query) on the `interaction_logs` table:
+2. [Run a query](../../../wiki/pgadmin.md#run-a-query) on the `interacts` table:
 
    ```sql
-   SELECT * FROM interaction_logs ORDER BY id DESC LIMIT 5;
+   SELECT * FROM interacts ORDER BY id DESC LIMIT 5;
    ```
 
 3. Verify that the row you just created appears in the results.
 
 ### 1.7. Send another request and check the database
 
-1. In `Swagger UI`, send another `POST /interaction_logs` request with different values.
+1. In `Swagger UI`, send another `POST /interactions` request with different values.
 2. In `pgAdmin`, run the query again and verify the new row appears.
 
 ### 1.8. Write a comment for the issue
 
-1. Take a screenshot of the browser developer tools `Network` tab showing the `POST /interaction_logs` request and response.
+1. Take a screenshot of the browser developer tools `Network` tab showing the `POST /interactions` request and response.
 2. Take a screenshot of `pgAdmin` showing the corresponding row in the database.
 3. Write a comment on the issue and paste both screenshots.
 4. Close the issue.

--- a/lab/tasks/setup.md
+++ b/lab/tasks/setup.md
@@ -315,7 +315,7 @@ Complete these steps if you can't [connect to your VM](../../wiki/vm.md#connect-
 
 1. [Open `pgAdmin`](../../wiki/pgadmin.md#open-pgadmin).
 2. [Add a server in `pgAdmin`](../../wiki/pgadmin.md#add-a-server-in-pgadmin).
-3. [Browse the `interaction_logs` table](../../wiki/pgadmin.md#browse-tables)
+3. [Browse the `interacts` table](../../wiki/pgadmin.md#browse-tables)
 
    You should see rows of data stored in the database.
 
@@ -327,7 +327,7 @@ Complete these steps if you can't [connect to your VM](../../wiki/vm.md#connect-
 4. Verify that the following tables exist and contain data:
    - `items`
    - `learners`
-   - `interaction_logs`
+   - `interacts`
 
 > [!TIP]
 > To view the data in a table, right-click the table and select `View/Edit Data` -> `All Rows`.

--- a/wiki/pgadmin.md
+++ b/wiki/pgadmin.md
@@ -78,7 +78,7 @@ Docs:
 4. Write your SQL query, e.g.:
 
    ```sql
-   SELECT * FROM interaction_logs WHERE item_id = 2;
+   SELECT * FROM interacts WHERE item_id = 2;
    ```
 
 5. Click `Execute Script` (or press `F5`).


### PR DESCRIPTION
## Summary

- Add the missing `POST /interactions` endpoint required by task-1 (model, db function, router handler)
- Fix all docs that incorrectly referenced `interaction_logs` to use actual names: `interacts` (DB table) and `/interactions` (API route)
- POST uses `InteractionLog` as response model so it works before students fix the `InteractionModel.timestamp` bug in task-2

## Changes

### Code
- `backend/app/models/interaction.py` — add `InteractionLogCreate` schema
- `backend/app/db/interactions.py` — add `create_interaction()` function
- `backend/app/routers/interactions.py` — add `POST /` endpoint with `IntegrityError` handling

### Docs
- `lab/tasks/required/task-1.md` — `POST /interaction_logs` → `POST /interactions`, `interaction_logs` table → `interacts` table
- `lab/tasks/setup.md` — `interaction_logs` → `interacts`
- `wiki/pgadmin.md` — SQL example uses `interacts` table
- `docs/design/architecture.md` — add POST to interactions router diagram and description

## Notes

- Intentional bugs in `_filter_by_item_id` and `InteractionModel.timestamp` are **preserved** — students fix these in task-2
- DB table naming follows the relationship-table convention from `conventions-lab.md` (verb: `interacts`)