### PR TITLE
fix(tasks): reintroduce intentional bugs for Task 2

### DIFF
--- a/backend/app/models/interaction.py
+++ b/backend/app/models/interaction.py
@@ -32,4 +32,4 @@ class InteractionModel(SQLModel):
     learner_id: int
     item_id: int
     kind: str
-    created_at: datetime
+    timestamp: datetime

--- a/backend/app/routers/interactions.py
+++ b/backend/app/routers/interactions.py
@@ -16,7 +16,7 @@ def _filter_by_item_id(
 ) -> list[InteractionLog]:
     if item_id is None:
         return interactions
-    return [i for i in interactions if i.item_id == item_id]
+    return [i for i in interactions if i.learner_id == item_id]
 
 
 @router.get("/", response_model=list[InteractionModel])


### PR DESCRIPTION
## Summary

The `improve-lab` branch (PR #13) accidentally fixed both intentional bugs that students discover and fix in Task 2. This PR reintroduces them:

- **Part A bug**: `_filter_by_item_id` compares `learner_id` instead of `item_id`
- **Part B bug**: `InteractionModel` uses `timestamp` instead of `created_at`