### PR TITLE
revert: remove leaked fork changes from PR #14

### DIFF
--- a/backend/tests/e2e/test_interactions.py
+++ b/backend/tests/e2e/test_interactions.py
@@ -1,13 +1,1 @@
 """End-to-end tests for the GET /interactions endpoint."""
-
-import httpx
-
-
-def test_get_interactions_returns_200(client: httpx.Client) -> None:
-    response = client.get("/interactions/")
-    assert response.status_code == 200
-
-
-def test_get_interactions_response_is_a_list(client: httpx.Client) -> None:
-    response = client.get("/interactions/")
-    assert isinstance(response.json(), list)

--- a/backend/tests/unit/test_interactions.py
+++ b/backend/tests/unit/test_interactions.py
@@ -24,28 +24,3 @@ def test_filter_returns_interaction_with_matching_ids() -> None:
     result = _filter_by_item_id(interactions, 1)
     assert len(result) == 1
     assert result[0].id == 1
-
-
-def test_filter_excludes_interaction_with_different_learner_id() -> None:
-    interactions = [_make_log(1, 2, 1)]
-    result = _filter_by_item_id(interactions, 1)
-    assert len(result) == 1
-
-
-def test_filter_returns_multiple_matches() -> None:
-    interactions = [_make_log(1, 1, 3), _make_log(2, 2, 3), _make_log(3, 1, 1)]
-    result = _filter_by_item_id(interactions, 3)
-    assert len(result) == 2
-
-
-def test_filter_returns_empty_when_no_match() -> None:
-    interactions = [_make_log(1, 1, 1), _make_log(2, 2, 2)]
-    result = _filter_by_item_id(interactions, 99)
-    assert result == []
-
-
-def test_filter_with_item_id_zero() -> None:
-    interactions = [_make_log(1, 1, 0), _make_log(2, 2, 1)]
-    result = _filter_by_item_id(interactions, 0)
-    assert len(result) == 1
-    assert result[0].id == 1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,6 @@ interface Item {
   id: number
   type: string
   title: string
-  description: string
   created_at: string
 }
 
@@ -94,7 +93,6 @@ function App() {
               <th>ID</th>
               <th>Type</th>
               <th>Title</th>
-              <th>Description</th>
               <th>Created at</th>
             </tr>
           </thead>
@@ -104,7 +102,6 @@ function App() {
                 <td>{item.id}</td>
                 <td>{item.type}</td>
                 <td>{item.title}</td>
-                <td>{item.description}</td>
                 <td>{item.created_at}</td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary

PR #14 was branched from the nurlingo fork instead of upstream/main, dragging in the entire fork history. PR #16 reintroduced the intentional bugs but these leaked changes were missed:

- **e2e tests** — students write these in Task 2 Part B (removed)
- **unit tests** — Task 2 answer + 3 AI-generated tests from Task 2 Part C (removed)
- **frontend** — `description` column from a separate fork task (removed)

`conftest.py` (the only intended change from PR #14) is kept.