### PR TITLE
Fix Lab 4 interactions FK metadata registration

### DIFF
--- a/backend/app/models/interaction.py
+++ b/backend/app/models/interaction.py
@@ -4,6 +4,11 @@ from datetime import datetime
 
 from sqlmodel import Field, SQLModel
 
+# Ensure referenced FK target tables are registered in SQLModel metadata
+# whenever InteractionLog is imported.
+from app.models.item import ItemRecord  # noqa: F401
+from app.models.learner import Learner  # noqa: F401
+
 
 class InteractionLog(SQLModel, table=True):
     """An interaction log entry in the database."""


### PR DESCRIPTION
Summary:
- Import learner and item models in backend/app/models/interaction.py
- Ensure SQLModel metadata contains FK target tables whenever InteractionLog is imported

Why:
- Fixes sqlalchemy NoReferencedTableError for interacts.learner_id to learner.id that caused /interactions/ requests to fail with 500

Test notes:
- Reproduced from runtime logs and traceback
- Full backend test run was not available in this shell environment