### PR TITLE
fix(docs): add deployed VM URL for Swagger UI

### DIFF
--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -48,9 +48,9 @@ Title: `[Task] Observe System Component Interaction`
 
 ### 1.3. Open `Swagger UI`
 
-1. Open `http://<your-vm-ip-address>:42002/docs` in a browser.
+1. Open in a browser: `http://<your-vm-ip-address>:42002/docs`.
 
-   See [`<your-vm-ip-address>`](../../../wiki/vm.md#your-vm-ip-address).
+   Replace [`<your-vm-ip-address>`](../../../wiki/vm.md#your-vm-ip-address) with the IP address of your VM.
 
 2. [Authorize](../../../wiki/swagger.md#authorize-in-swagger-ui) with the API key.
 

--- a/wiki/swagger.md
+++ b/wiki/swagger.md
@@ -29,9 +29,9 @@ Actions:
 
 **On a deployed VM:**
 
-1. Open `http://<your-vm-ip-address>:42002/docs` in a browser.
+1. Open in a browser: `http://<your-vm-ip-address>:42002/docs`.
 
-   See [`<your-vm-ip-address>`](./vm.md#your-vm-ip-address).
+   Replace [`<your-vm-ip-address>`](./vm.md#your-vm-ip-address) with the IP address of your VM.
 
 ## Authorize in `Swagger UI`
 


### PR DESCRIPTION
## Summary

- **wiki/swagger.md**: Added "On a deployed VM" section with `http://<your-vm-ip-address>:42002/docs` (Caddy port). Previously only had the localhost URL (`127.0.0.1:42001`).
- **task-1.md step 1.3**: Replaced the generic wiki link with the explicit VM URL and a reference to `<your-vm-ip-address>`. Students deploy to a VM in step 1.2 but had no way to know which port to use for Swagger UI.