### PR TITLE
fix: filter interactions by item_id instead of learner_id

### DIFF
--- a/backend/app/routers/interactions.py
+++ b/backend/app/routers/interactions.py
@@ -16,7 +16,7 @@ def _filter_by_item_id(
 ) -> list[InteractionLog]:
     if item_id is None:
         return interactions
-    return [i for i in interactions if i.learner_id == item_id]
+    return [i for i in interactions if i.item_id == item_id]
 
 
 @router.get("/", response_model=list[InteractionModel])

--- a/backend/tests/unit/test_interactions.py
+++ b/backend/tests/unit/test_interactions.py
@@ -24,3 +24,10 @@ def test_filter_returns_interaction_with_matching_ids() -> None:
     result = _filter_by_item_id(interactions, 1)
     assert len(result) == 1
     assert result[0].id == 1
+
+def test_filter_excludes_interaction_with_different_learner_id() -> None:
+    interactions = [_make_log(1, 2, 1)]
+    result = _filter_by_item_id(interactions, 1)
+    assert len(result) == 1
+    assert result[0].learner_id == 2
+    assert result[0].item_id == 1


### PR DESCRIPTION
[root@se-toolkit001:~/se-toolkit-lab-4# git pull origin main
From https://github.com/Send4etup/se-toolkit-lab-4
 * branch            main       -> FETCH_HEAD
Already up to date.
root@se-toolkit001:~/se-toolkit-lab-4#](fix: filter interactions by item_id instead of learner_id)